### PR TITLE
infra: bump Go to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/benaskins/axon-eval
 
-go 1.26.0
+go 1.26.1
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Fixes govulncheck failures from 4 Go stdlib vulnerabilities (GO-2026-4599, GO-2026-4600, GO-2026-4601, GO-2026-4602) fixed in go1.26.1.